### PR TITLE
カメラ読み込み機能の実装

### DIFF
--- a/shellme.xcodeproj/project.pbxproj
+++ b/shellme.xcodeproj/project.pbxproj
@@ -190,6 +190,7 @@
 			developmentRegion = ja;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				ja,
 				en,
 				Base,
 			);
@@ -399,6 +400,7 @@
 				DEVELOPMENT_TEAM = 36S326MPS3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "カメラで映したテキストを入力するために利用許可が必要です。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -428,6 +430,7 @@
 				DEVELOPMENT_TEAM = 36S326MPS3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "カメラで映したテキストを入力するために利用許可が必要です。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/shellme/ContentView.swift
+++ b/shellme/ContentView.swift
@@ -77,26 +77,10 @@ struct ContentView: View {
                         VStack {
                             Spacer()
                             HStack {
-                                Button(action: {
-                                    isAllDeleteDialogPresented = true
-                                }) {
-                                    Image(systemName: "trash")
+                                NavigationLink(destination: ScannerView()) {
+                                    Image(systemName: "camera")
                                 }
                                 .dangerCircleButton(size: .xlarge)
-                                .confirmationDialog(
-                                    "全商品の削除",
-                                    isPresented: $isAllDeleteDialogPresented,
-                                    titleVisibility: .visible
-                                ) {
-                                    Button("削除", role: .destructive) {
-                                        deleteAllItems()
-                                    }
-                                    Button("キャンセル", role: .cancel) {
-                                        isAllDeleteDialogPresented = false
-                                    }
-                                } message: {
-                                    Text("リスト内の全ての商品が削除されます。削除したデータは戻りません。")
-                                }
 
                                 Spacer()
 
@@ -111,6 +95,24 @@ struct ContentView: View {
                         }
                     }
                 }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(role: .destructive) {
+                        isAllDeleteDialogPresented = true
+                    } label: {
+                        Image(systemName: "trash")
+                            .foregroundColor(.red)
+                    }
+                }
+            }
+            .alert("すべてのアイテムを削除しますか？", isPresented: $isAllDeleteDialogPresented) {
+                Button("キャンセル", role: .cancel) {}
+                Button("削除", role: .destructive) {
+                    deleteAllItems()
+                }
+            } message: {
+                Text("この操作は元に戻せません。")
             }
         }
         .sheet(isPresented: $isAddFormPresented) {

--- a/shellme/ContentView.swift
+++ b/shellme/ContentView.swift
@@ -80,7 +80,7 @@ struct ContentView: View {
                                 NavigationLink(destination: ScannerView()) {
                                     Image(systemName: "camera")
                                 }
-                                .dangerCircleButton(size: .xlarge)
+                                .secondaryCircleButton(size: .xlarge)
 
                                 Spacer()
 

--- a/shellme/ContentView.swift
+++ b/shellme/ContentView.swift
@@ -15,14 +15,14 @@ struct ContentView: View {
     @State private var isAllDeleteDialogPresented = false
 
     private var totalPrice: Int {
-        items.reduce(0) { sum, item in
+        let total: Float = items.reduce(0) { sum, item in
             if let price = item.price {
-                return sum + (item.amount * price)
+                return sum + (Float(item.amount) * price)
             }
             return sum
         }
+        return Int(total)
     }
-
     var body: some View {
         NavigationView {
             ZStack {

--- a/shellme/Model/Item.swift
+++ b/shellme/Model/Item.swift
@@ -12,9 +12,9 @@ import SwiftData
 final class Item {
     var name: String
     var amount: Int
-    var price: Int?
+    var price: Float?
 
-    init(name: String, amount: Int, price: Int? = nil) {
+    init(name: String, amount: Int, price: Float? = nil) {
         self.name = name
         self.amount = amount
         self.price = price
@@ -35,5 +35,6 @@ final class Item {
         Item(name: "聲の形", amount: 30000, price: 1000),
         Item(name: "All You Need Is Kill", amount: 3, price: 10000),
         Item(name: "﷽﷽﷽", amount: 3, price: 10000),
+        Item(name: "小数点の値段", amount: 3, price: 100.11)
     ]
 }

--- a/shellme/ViewComponents/Buttons/PrimaryCircleButton.swift
+++ b/shellme/ViewComponents/Buttons/PrimaryCircleButton.swift
@@ -66,9 +66,11 @@ private struct PrimaryCircleButtonStyleView: View {
         label
             .font(.system(size: fontSize, weight: .bold))
             .foregroundStyle(iconColor)
-            .frame(width: size.padding.leading * 2, height: size.padding.top + size.padding.bottom)
             .padding(size.padding)
-            .background(primaryBackgroundColor)
+            .background(
+                Circle()
+                    .fill(primaryBackgroundColor)
+            )
             .overlay(
                 Circle()
                     .fill(Color.white.opacity(isPressed ? 0.3 : 0.0))
@@ -77,7 +79,7 @@ private struct PrimaryCircleButtonStyleView: View {
                 Circle()
                     .fill(Color.white.opacity(isEnabled ? 0.0 : 0.6))
             )
-            .clipShape(Circle())
+            .contentShape(Circle()) // 当たり判定を丸に限定
     }
 }
 

--- a/shellme/ViewComponents/Buttons/SecondaryCircleButton.swift
+++ b/shellme/ViewComponents/Buttons/SecondaryCircleButton.swift
@@ -1,5 +1,5 @@
 //
-//  SecondaryButton.swift
+//  SecondaryCircleButton.swift
 //  shellme
 //
 //  Created by 斉藤祐大 on 2025/02/02.
@@ -12,27 +12,27 @@ extension View {
         size: ButtonSize
     ) -> some View {
         return modifier(
-            SecondaryButtonStyleModifier(size: size))
+            SecondaryCircleButtonStyleModifier(size: size))
     }
 }
 
-private struct SecondaryButtonStyleModifier: ViewModifier {
+private struct SecondaryCircleButtonStyleModifier: ViewModifier {
     @Environment(\.isEnabled) var isEnabled
     let size: ButtonSize
 
     func body(content: Content) -> some View {
         content.buttonStyle(
-            SecondaryButtonStyle(
+            SecondaryCircleButtonStyle(
                 isEnabled: isEnabled, size: size))
     }
 }
 
-private struct SecondaryButtonStyle: ButtonStyle {
+private struct SecondaryCircleButtonStyle: ButtonStyle {
     let isEnabled: Bool
     let size: ButtonSize
 
     func makeBody(configuration: Self.Configuration) -> some View {
-        SecondaryButtonStyleView(
+        SecondaryCircleButtonStyleView(
             label: configuration.label,
             isPressed: configuration.isPressed,
             isEnabled: isEnabled,
@@ -41,7 +41,7 @@ private struct SecondaryButtonStyle: ButtonStyle {
     }
 }
 
-private struct SecondaryButtonStyleView: View {
+private struct SecondaryCircleButtonStyleView: View {
     let label: ButtonStyleConfiguration.Label
     let isPressed: Bool
     let isEnabled: Bool

--- a/shellme/ViewComponents/Buttons/SecondaryCircleButton.swift
+++ b/shellme/ViewComponents/Buttons/SecondaryCircleButton.swift
@@ -1,5 +1,5 @@
 //
-//  DangerCircleButton.swift
+//  SecondaryButton.swift
 //  shellme
 //
 //  Created by 斉藤祐大 on 2025/02/02.
@@ -8,31 +8,31 @@
 import SwiftUI
 
 extension View {
-    public func dangerCircleButton(
+    public func secondaryCircleButton(
         size: ButtonSize
     ) -> some View {
         return modifier(
-            DangerCircleButtonStyleModifier(size: size))
+            SecondaryButtonStyleModifier(size: size))
     }
 }
 
-private struct DangerCircleButtonStyleModifier: ViewModifier {
+private struct SecondaryButtonStyleModifier: ViewModifier {
     @Environment(\.isEnabled) var isEnabled
     let size: ButtonSize
 
     func body(content: Content) -> some View {
         content.buttonStyle(
-            DangerCircleButtonStyle(
+            SecondaryButtonStyle(
                 isEnabled: isEnabled, size: size))
     }
 }
 
-private struct DangerCircleButtonStyle: ButtonStyle {
+private struct SecondaryButtonStyle: ButtonStyle {
     let isEnabled: Bool
     let size: ButtonSize
 
     func makeBody(configuration: Self.Configuration) -> some View {
-        DangerCircleButtonStyleView(
+        SecondaryButtonStyleView(
             label: configuration.label,
             isPressed: configuration.isPressed,
             isEnabled: isEnabled,
@@ -41,12 +41,13 @@ private struct DangerCircleButtonStyle: ButtonStyle {
     }
 }
 
-private struct DangerCircleButtonStyleView: View {
+private struct SecondaryButtonStyleView: View {
     let label: ButtonStyleConfiguration.Label
     let isPressed: Bool
     let isEnabled: Bool
     let size: ButtonSize
-    private let color: Color = Color.red
+    private let color: Color = Color.pink
+    private let secondaryBackgroundColor: Color = Color(.systemGroupedBackground)
 
     @ScaledMetric var fontSize: CGFloat
 
@@ -69,8 +70,11 @@ private struct DangerCircleButtonStyleView: View {
         label
             .font(.system(size: fontSize, weight: .bold))
             .foregroundStyle(color)
-            .frame(width: size.padding.leading * 2, height: size.padding.top + size.padding.bottom)
             .padding(size.padding)
+            .background(
+                Circle()
+                    .fill(secondaryBackgroundColor)
+            )
             .overlay(
                 Circle()
                     .strokeBorder(color, lineWidth: size.borderWidth)
@@ -83,6 +87,7 @@ private struct DangerCircleButtonStyleView: View {
                 Circle()
                     .fill(Color.white.opacity(isEnabled ? 0.0 : 0.6))
             )
+            .contentShape(Circle()) // 当たり判定を丸に限定
     }
 }
 
@@ -104,7 +109,7 @@ private struct DangerCircleButtonStyleView: View {
                 }) {
                     Image(systemName: "trash")
                 }
-                .dangerCircleButton(size: buttonSize.size)
+                .secondaryCircleButton(size: buttonSize.size)
                 .frame(maxWidth: .infinity, alignment: .center)
             }
         }
@@ -118,7 +123,7 @@ private struct DangerCircleButtonStyleView: View {
                 }) {
                     Image(systemName: "trash")
                 }
-                .dangerCircleButton(size: buttonSize.size)
+                .secondaryCircleButton(size: buttonSize.size)
                 .disabled(true)
                 .frame(maxWidth: .infinity, alignment: .center)
             }

--- a/shellme/ViewComponents/Forms/CreateItemForm.swift
+++ b/shellme/ViewComponents/Forms/CreateItemForm.swift
@@ -30,7 +30,7 @@ struct CreateItemForm: View {
             .padding(.vertical)
             RepresentableTextField(
                 text: $price, placeholder: "Price (optional)",
-                keyboardType: .numberPad
+                keyboardType: .decimalPad
             )
             .padding(.vertical)
             Button("保存") {
@@ -43,7 +43,7 @@ struct CreateItemForm: View {
     }
 
     private func saveItem() {
-        let item = Item(name: name, amount: Int(amount) ?? 1, price: Int(price))
+        let item = Item(name: name, amount: Int(amount) ?? 1, price: Float(price))
         modelContext.insert(item)
     }
 

--- a/shellme/ViewComponents/Forms/EditItemForm.swift
+++ b/shellme/ViewComponents/Forms/EditItemForm.swift
@@ -30,8 +30,8 @@ struct EditItemForm: View {
             .padding(.vertical)
             RepresentableTextField(
                 text: Binding(
-                    get: { item.price.map(String.init) ?? "" },
-                    set: { item.price = Int($0) }
+                    get: { item.price.map { String($0) } ?? "" },
+                    set: { item.price = Float($0) }
                 ),
                 placeholder: "Price (optional)",
                 keyboardType: .numberPad

--- a/shellme/ViewComponents/Scanners/DataScanner.swift
+++ b/shellme/ViewComponents/Scanners/DataScanner.swift
@@ -1,0 +1,140 @@
+//
+//  DataScanner.swift
+//  shellme
+//
+//  Created by 斉藤祐大 on 2025/02/16.
+//
+
+import Foundation
+import SwiftUI
+import VisionKit
+
+struct DataScanner: UIViewControllerRepresentable {
+    @Binding var isScanning: Bool
+    @Binding var isShowAlert: Bool
+    @Binding var isLoading: Bool
+    @Binding var name: String
+    @Binding var price: String
+
+    func makeUIViewController(context: Context) -> DataScannerViewController {
+        let controller = DataScannerViewController(
+            recognizedDataTypes: [.text()],
+            qualityLevel: .accurate,
+            recognizesMultipleItems: false,
+            isPinchToZoomEnabled: true,
+            isHighlightingEnabled: true)
+
+        controller.delegate = context.coordinator
+
+        return controller
+    }
+
+    func updateUIViewController(
+        _ uiViewController: DataScannerViewController, context: Context
+    ) {
+        if isScanning {
+            do {
+                try uiViewController.startScanning()
+
+            } catch (let error) {
+                print(error)
+            }
+
+        } else {
+            uiViewController.stopScanning()
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, DataScannerViewControllerDelegate {
+        var parent: DataScanner
+
+        init(_ parent: DataScanner) {
+            self.parent = parent
+        }
+
+        func dataScanner(
+            _ dataScanner: DataScannerViewController,
+            didTapOn item: RecognizedItem
+        ) {
+            if case .text(let text) = item {
+                self.parent.isLoading = true
+                sendTextToAPI(text.transcript)
+            }
+
+        }
+
+        func dataScanner(
+            _ dataScanner: DataScannerViewController,
+            becameUnavailableWithError error: DataScannerViewController
+                .ScanningUnavailable
+        ) {
+            switch error {
+            case .cameraRestricted:
+                print("カメラの使用を許可してください。")
+                parent.isShowAlert = true
+
+            case .unsupported:
+                print("このデバイスをはサポートされていません。")
+
+            default:
+                print(error.localizedDescription)
+            }
+        }
+
+        private func sendTextToAPI(_ text: String) {
+            guard
+                let url = URL(
+                    string:
+                        "https://shellme-backend.seifuzi2064.workers.dev/api/parse-price-tag"
+                )
+            else {
+                return
+            }
+
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue(
+                "application/json", forHTTPHeaderField: "Content-Type")
+
+            let requestBody: [String: Any] = ["text": text]
+            request.httpBody = try? JSONSerialization.data(
+                withJSONObject: requestBody)
+
+            let task = URLSession.shared.dataTask(with: request) {
+                data, response, error in
+                guard let data = data, error == nil else {
+                    print(
+                        "Request failed: \(error?.localizedDescription ?? "Unknown error")"
+                    )
+                    return
+                }
+
+                do {
+                    let jsonResponse =
+                        try JSONSerialization.jsonObject(
+                            with: data, options: []) as? [String: Any]
+                    if let name = jsonResponse?["name"] as? String,
+                        let price = jsonResponse?["price"] as? NSNumber
+                    {
+
+                        DispatchQueue.main.async {
+                            self.parent.name = name
+                            self.parent.price = price.stringValue
+                            self.parent.isLoading = false
+                        }
+                    }
+                } catch {
+                    print("JSON decoding failed: \(error.localizedDescription)")
+                    DispatchQueue.main.async {
+                        self.parent.isLoading = false
+                    }
+                }
+            }
+            task.resume()
+        }
+    }
+}

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -1,0 +1,79 @@
+//
+//  ScannerView.swift
+//  shellme
+//
+//  Created by 斉藤祐大 on 2025/02/16.
+//
+
+import SwiftData
+import SwiftUI
+
+struct ScannerView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var isScanning: Bool = false
+    @State private var isShowAlert: Bool = false
+    @State private var isLoading: Bool = false
+    @State private var name: String = ""
+    @State private var amount: String = ""
+    @State private var price: String = ""
+
+    var body: some View {
+        VStack {
+            DataScanner(
+                isScanning: $isScanning,
+                isShowAlert: $isShowAlert,
+                isLoading: $isLoading,
+                name: $name,
+                price: $price
+            )
+
+            if isLoading {
+                ProgressView("読み込み中...")
+                    .progressViewStyle(CircularProgressViewStyle())
+                    .padding()
+            }
+
+            Form {
+                RepresentableTextField(
+                    text: $name, placeholder: "商品"
+                )
+                .padding(.vertical)
+                RepresentableTextField(
+                    text: $amount, placeholder: "個数", keyboardType: .numberPad
+                )
+                .padding(.vertical)
+                RepresentableTextField(
+                    text: $price, placeholder: "Price (optional)",
+                    keyboardType: .numberPad
+                )
+                .padding(.vertical)
+                Button("保存") {
+                    saveItem()
+                    resetForm()
+                    dismiss()
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .task {
+            isScanning.toggle()
+        }
+    }
+
+    private func saveItem() {
+        let item = Item(name: name, amount: Int(amount) ?? 1, price: Int(price))
+        modelContext.insert(item)
+    }
+
+    private func resetForm() {
+        name = ""
+        amount = ""
+        price = ""
+    }
+}
+
+#Preview {
+    ScannerView()
+}

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -46,7 +46,7 @@ struct ScannerView: View {
                 .padding(.vertical)
                 RepresentableTextField(
                     text: $price, placeholder: "Price (optional)",
-                    keyboardType: .numberPad
+                    keyboardType: .decimalPad
                 )
                 .padding(.vertical)
                 Button("保存") {
@@ -63,7 +63,7 @@ struct ScannerView: View {
     }
 
     private func saveItem() {
-        let item = Item(name: name, amount: Int(amount) ?? 1, price: Int(price))
+        let item = Item(name: name, amount: Int(amount) ?? 1, price: Float(price))
         modelContext.insert(item)
     }
 


### PR DESCRIPTION
## 実装した機能
- 以下のようにカメラで値札を読み込むと自動で商品名と値段が入力される
  - 文字の認識範囲の調整が難しく、正直手で入力した方が早い・・・

https://github.com/user-attachments/assets/7f30f239-8f5b-42b3-8582-e1290cc74820

## 検討した仕様
- 値札の文字列を直接読み込む形式ではなく、バーコードの値を読み込む
  - 値札の文字列を直接読み込む形式だと、値段と商品名を読み込んで欲しいのに、別のところにフォーカス当たったりするのが厄介
  - バーコード形式なら、この問題を解決できるのだが、バーコードと照会できる良い外部APIがなさそうだった
    - [バーコードで商品検索](https://apps.apple.com/jp/app/%E3%83%90%E3%83%BC%E3%82%B3%E3%83%BC%E3%83%89%E3%81%A7%E5%95%86%E5%93%81%E6%A4%9C%E7%B4%A2/id1135134460)とかかYahoo APIを使っていそうだが、使ってみたところ殆ど商品がヒットしない・・・
    - [JANCODE LOOKUP](https://www.jancodelookup.com/)も同様
- 読み込んだテキストをフォーマットするのに、ローカルLLMの採用も検討した
  - https://github.com/ggml-org/llama.cpp/discussions/256
  - 上では大体数十GBと報告する人が多いのでこれをアプリに入れるのはキツそうと結論に

## 変更点
- 削除ボタンの位置の変更
  - 削除ボタンの位置にカメラボタンを用意したいので、削除ボタンはtoolbarに移動
  - それに伴い、DangerCircleButtonは削除し、SecondaryCircleButtonに変更
- 税込価格は小数になることもあるので少数を入力可能に変更
- 少数入力に伴いtotalPriceの計算方法も変更
  - 以下のように記載があるので、このアプリでは切り捨てを選択
  - また、個別に端数を処理するのではなく、合計した後に端数を切り捨てることにする

> https://ashiyakaikei.com/consumption-tax-fraction/
> 小売店（スーパーマーケット、ドラッグストア、コンビニなど）では、顧客の利益になることから消費税の端数を切り捨てるケースが多くなっています。
企業間取引でも”切り捨て”が採用されるケースが多いので、どの端数処理方法にするか迷ったときは”切り捨て”を選ぶと良いでしょう。

> 例えば、次のように個々の商品ごとに消費税の端数処理をすることはできません。
いちご：税抜5880円（消費税470.4円 → 470円）
りんご：税抜3920円（消費税313.6円 → 313円）
バナナ：税抜2880円（消費税230.4円 → 230円）
すべての商品を税率ごとに合計してから消費税を算出して端数処理をする必要があります。
> 標準税率10%と軽減税率８％が混在している場合は、それぞれの税率で端数処理をしてから合計額を記載します。
