### PR TITLE
Item入力値のバリデーションの実装

### DIFF
--- a/shellme/Model/ItemAmountValidator.swift
+++ b/shellme/Model/ItemAmountValidator.swift
@@ -1,0 +1,39 @@
+//
+//  ItemAmountValidator.swift
+//  shellme
+//
+//  Created by 斉藤祐大 on 2025/02/24.
+//
+
+import Foundation
+
+struct ItemAmountValidator: Validator {
+    let amount: String
+
+    enum Result: ValidationResult {
+        case none
+        case required(String)
+        case isNotNumber(String)
+        case isLessThanOne(String)
+
+        var isOk: Bool {
+            if case .none = self { return true } else { return false }
+        }
+    }
+
+    func validate() -> Result {
+        if amount.isEmpty {
+            return .required("個数が入力されていません")
+        }
+        
+        guard let intAmount = Int(amount) else {
+            return .isNotNumber("個数は半角で、整数値を入力してください")
+        }
+        
+        if intAmount < 1 {
+            return .isLessThanOne("個数は1以上の整数入力してください")
+        }
+
+        return .none
+    }
+}

--- a/shellme/Model/ItemAmountValidator.swift
+++ b/shellme/Model/ItemAmountValidator.swift
@@ -19,17 +19,26 @@ struct ItemAmountValidator: Validator {
         var isOk: Bool {
             if case .none = self { return true } else { return false }
         }
+
+        var errorMessage: String? {
+            switch self {
+            case .none: return nil
+            case .required(let msg), .isNotNumber(let msg),
+                .isLessThanOne(let msg):
+                return msg
+            }
+        }
     }
 
     func validate() -> Result {
         if amount.isEmpty {
             return .required("個数が入力されていません")
         }
-        
+
         guard let intAmount = Int(amount) else {
             return .isNotNumber("個数は半角で、整数値を入力してください")
         }
-        
+
         if intAmount < 1 {
             return .isLessThanOne("個数は1以上の整数入力してください")
         }

--- a/shellme/Model/ItemNameValidator.swift
+++ b/shellme/Model/ItemNameValidator.swift
@@ -1,0 +1,29 @@
+//
+//  ItemNameValidator.swift
+//  shellme
+//
+//  Created by 斉藤祐大 on 2025/02/24.
+//
+
+import Foundation
+
+struct ItemNameValidator: Validator {
+    let name: String
+
+    enum Result: ValidationResult {
+        case none
+        case required(String)
+
+        var isOk: Bool {
+            if case .none = self { return true } else { return false }
+        }
+    }
+
+    func validate() -> Result {
+        if name.isEmpty {
+            return .required("商品名が入力されていません")
+        }
+
+        return .none
+    }
+}

--- a/shellme/Model/ItemNameValidator.swift
+++ b/shellme/Model/ItemNameValidator.swift
@@ -17,6 +17,14 @@ struct ItemNameValidator: Validator {
         var isOk: Bool {
             if case .none = self { return true } else { return false }
         }
+
+        var errorMessage: String? {
+            switch self {
+            case .none: return nil
+            case .required(let msg):
+                return msg
+            }
+        }
     }
 
     func validate() -> Result {

--- a/shellme/Model/ItemPriceValidator.swift
+++ b/shellme/Model/ItemPriceValidator.swift
@@ -17,6 +17,14 @@ struct ItemPriceValidator: Validator {
         var isOk: Bool {
             if case .none = self { return true } else { return false }
         }
+
+        var errorMessage: String? {
+            switch self {
+            case .none: return nil
+            case .isNotNumber(let msg):
+                return msg
+            }
+        }
     }
 
     func validate() -> Result {

--- a/shellme/Model/ItemPriceValidator.swift
+++ b/shellme/Model/ItemPriceValidator.swift
@@ -1,0 +1,33 @@
+//
+//  ItemPriceValidator.swift
+//  shellme
+//
+//  Created by 斉藤祐大 on 2025/02/24.
+//
+
+import Foundation
+
+struct ItemPriceValidator: Validator {
+    let price: String
+
+    enum Result: ValidationResult {
+        case none
+        case isNotNumber(String)
+
+        var isOk: Bool {
+            if case .none = self { return true } else { return false }
+        }
+    }
+
+    func validate() -> Result {
+        if price.isEmpty {
+            return .none
+        }
+
+        if Float(price) == nil {
+            return .isNotNumber("値段には数字を入力してください")
+        }
+
+        return .none
+    }
+}

--- a/shellme/Model/Validator.swift
+++ b/shellme/Model/Validator.swift
@@ -18,16 +18,9 @@ extension Validator {
 
 protocol ValidationResult {
     var isOk: Bool { get }
+    var errorMessage: String? { get }
 }
 
 extension ValidationResult {
     var isNg: Bool { !isOk }
-}
-
-extension Array where Element == ValidationResult {
-    var isValidAll: Bool {
-        if contains(where: { $0.isNg }) { return false }
-        return true
-    }
-    var isInvalidAny: Bool { !isValidAll }
 }

--- a/shellme/Model/Validator.swift
+++ b/shellme/Model/Validator.swift
@@ -1,0 +1,33 @@
+//
+//  Validator.swift
+//  shellme
+//
+//  Created by 斉藤祐大 on 2025/02/24.
+//
+
+import Foundation
+
+protocol Validator {
+    associatedtype ResultType: ValidationResult
+    func validate() -> ResultType
+}
+
+extension Validator {
+    func isValid() -> Bool { validate().isOk }
+}
+
+protocol ValidationResult {
+    var isOk: Bool { get }
+}
+
+extension ValidationResult {
+    var isNg: Bool { !isOk }
+}
+
+extension Array where Element == ValidationResult {
+    var isValidAll: Bool {
+        if contains(where: { $0.isNg }) { return false }
+        return true
+    }
+    var isInvalidAny: Bool { !isValidAll }
+}

--- a/shellme/ViewComponents/Forms/CreateItemForm.swift
+++ b/shellme/ViewComponents/Forms/CreateItemForm.swift
@@ -16,6 +16,7 @@ struct CreateItemForm: View {
     @State private var price: String = ""
     @State private var nameError: String?
     @State private var amountError: String?
+    @State private var priceError: String?
 
     @FocusState var focus: Bool
 
@@ -53,9 +54,12 @@ struct CreateItemForm: View {
             }
 
             VStack(alignment: .leading) {
-                Text("値段")
-                    .font(.caption)
-                    .foregroundStyle(.gray)
+                Text("値段").font(.caption).foregroundStyle(.gray)
+
+                if let priceError {
+                    Text(priceError).font(.caption).foregroundColor(.red)
+                }
+
                 RepresentableTextField(
                     text: $price, placeholder: "値段",
                     keyboardType: .decimalPad
@@ -73,8 +77,9 @@ struct CreateItemForm: View {
     private func validateAndSave() {
         let nameHasError = validateName()
         let amountHasError = validateAmount()
+        let priceHasError = validatePrice()
 
-        if nameHasError || amountHasError {
+        if nameHasError || amountHasError || priceHasError {
             return
         }
 
@@ -107,6 +112,20 @@ struct CreateItemForm: View {
             return true
         case .none:
             amountError = nil
+            return false
+        }
+    }
+
+    private func validatePrice() -> Bool {
+        let priceValidator = ItemPriceValidator(price: price)
+        let priceResult = priceValidator.validate()
+
+        switch priceResult {
+        case .isNotNumber(let priceMessage):
+            priceError = priceMessage
+            return true
+        case .none:
+            priceError = nil
             return false
         }
     }

--- a/shellme/ViewComponents/Forms/CreateItemForm.swift
+++ b/shellme/ViewComponents/Forms/CreateItemForm.swift
@@ -91,43 +91,24 @@ struct CreateItemForm: View {
         let nameValidator = ItemNameValidator(name: name)
         let nameResult = nameValidator.validate()
 
-        switch nameResult {
-        case .required(let nameMessage):
-            nameError = nameMessage
-            return true
-        case .none:
-            nameError = nil
-            return false
-        }
+        nameError = nameResult.errorMessage
+        return nameResult.isNg
     }
 
     private func validateAmount() -> Bool {
         let amountValidator = ItemAmountValidator(amount: amount)
         let amountResult = amountValidator.validate()
 
-        switch amountResult {
-        case .required(let amountMessage), .isNotNumber(let amountMessage),
-            .isLessThanOne(let amountMessage):
-            amountError = amountMessage
-            return true
-        case .none:
-            amountError = nil
-            return false
-        }
+        amountError = amountResult.errorMessage
+        return amountResult.isNg
     }
 
     private func validatePrice() -> Bool {
         let priceValidator = ItemPriceValidator(price: price)
         let priceResult = priceValidator.validate()
-
-        switch priceResult {
-        case .isNotNumber(let priceMessage):
-            priceError = priceMessage
-            return true
-        case .none:
-            priceError = nil
-            return false
-        }
+        
+        priceError = priceResult.errorMessage
+        return priceResult.isNg
     }
 
     private func saveItem() {

--- a/shellme/ViewComponents/Forms/CreateItemForm.swift
+++ b/shellme/ViewComponents/Forms/CreateItemForm.swift
@@ -42,7 +42,7 @@ struct CreateItemForm: View {
                     Text("個数").font(.caption).foregroundStyle(.gray)
                     Text("*").foregroundColor(.red)
                 }
-                
+
                 if let amountError {
                     Text(amountError).font(.caption).foregroundColor(.red)
                 }
@@ -112,8 +112,7 @@ struct CreateItemForm: View {
     }
 
     private func saveItem() {
-        let item = Item(
-            name: name, amount: Int(amount) ?? 1, price: Float(price))
+        let item = Item(name: name, amount: Int(amount)!, price: Float(price))
         modelContext.insert(item)
     }
 

--- a/shellme/ViewComponents/Forms/CreateItemForm.swift
+++ b/shellme/ViewComponents/Forms/CreateItemForm.swift
@@ -15,6 +15,7 @@ struct CreateItemForm: View {
     @State private var amount: String = ""
     @State private var price: String = ""
     @State private var nameError: String?
+    @State private var amountError: String?
 
     @FocusState var focus: Bool
 
@@ -37,9 +38,15 @@ struct CreateItemForm: View {
             }
 
             VStack(alignment: .leading) {
-                Text("個数")
-                    .font(.caption)
-                    .foregroundStyle(.gray)
+                HStack {
+                    Text("個数").font(.caption).foregroundStyle(.gray)
+                    Text("*").foregroundColor(.red)
+                }
+                
+                if let amountError {
+                    Text(amountError).font(.caption).foregroundColor(.red)
+                }
+
                 RepresentableTextField(
                     text: $amount, placeholder: "個数", keyboardType: .numberPad
                 )
@@ -64,17 +71,43 @@ struct CreateItemForm: View {
     }
 
     private func validateAndSave() {
-        let validator = ItemNameValidator(name: name)
-        let result = validator.validate()
+        let nameHasError = validateName()
+        let amountHasError = validateAmount()
 
-        switch result {
-        case .required(let message):
-            nameError = message
+        if nameHasError || amountHasError {
             return
+        }
+
+        saveItem()
+        resetForm()
+    }
+
+    private func validateName() -> Bool {
+        let nameValidator = ItemNameValidator(name: name)
+        let nameResult = nameValidator.validate()
+
+        switch nameResult {
+        case .required(let nameMessage):
+            nameError = nameMessage
+            return true
         case .none:
             nameError = nil
-            saveItem()
-            resetForm()
+            return false
+        }
+    }
+
+    private func validateAmount() -> Bool {
+        let amountValidator = ItemAmountValidator(amount: amount)
+        let amountResult = amountValidator.validate()
+
+        switch amountResult {
+        case .required(let amountMessage), .isNotNumber(let amountMessage),
+            .isLessThanOne(let amountMessage):
+            amountError = amountMessage
+            return true
+        case .none:
+            amountError = nil
+            return false
         }
     }
 

--- a/shellme/ViewComponents/Forms/CreateItemForm.swift
+++ b/shellme/ViewComponents/Forms/CreateItemForm.swift
@@ -14,14 +14,22 @@ struct CreateItemForm: View {
     @State private var name: String = ""
     @State private var amount: String = ""
     @State private var price: String = ""
+    @State private var nameError: String?
+
     @FocusState var focus: Bool
 
     var body: some View {
         Form {
             VStack(alignment: .leading) {
-                Text("商品名")
-                    .font(.caption)
-                    .foregroundStyle(.gray)
+                HStack {
+                    Text("商品名").font(.caption).foregroundStyle(.gray)
+                    Text("*").foregroundColor(.red)
+                }
+                if let nameError {
+                    Text(nameError)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
                 RepresentableTextField(
                     text: $name, placeholder: "商品名", isFirstResponder: true
                 )
@@ -48,12 +56,26 @@ struct CreateItemForm: View {
             }
 
             Button("保存") {
-                saveItem()
-                resetForm()
+                validateAndSave()
             }
             .frame(maxWidth: .infinity)
         }
         .presentationDetents([.fraction(0.4)])
+    }
+
+    private func validateAndSave() {
+        let validator = ItemNameValidator(name: name)
+        let result = validator.validate()
+
+        switch result {
+        case .required(let message):
+            nameError = message
+            return
+        case .none:
+            nameError = nil
+            saveItem()
+            resetForm()
+        }
     }
 
     private func saveItem() {

--- a/shellme/ViewComponents/Forms/EditItemForm.swift
+++ b/shellme/ViewComponents/Forms/EditItemForm.swift
@@ -30,9 +30,10 @@ struct EditItemForm: View {
     var body: some View {
         Form {
             VStack(alignment: .leading) {
-                Text("商品名")
-                    .font(.caption)
-                    .foregroundStyle(.gray)
+                HStack {
+                    Text("商品名").font(.caption).foregroundStyle(.gray)
+                    Text("*").foregroundColor(.red)
+                }
 
                 if let nameError {
                     Text(nameError)

--- a/shellme/ViewComponents/Forms/EditItemForm.swift
+++ b/shellme/ViewComponents/Forms/EditItemForm.swift
@@ -128,7 +128,7 @@ struct EditItemForm: View {
 
     private func saveChanges() {
         item.name = name
-        item.amount = Int(amount) ?? 0
+        item.amount = Int(amount)!
         item.price = Float(price) ?? nil
     }
 }

--- a/shellme/ViewComponents/Forms/EditItemForm.swift
+++ b/shellme/ViewComponents/Forms/EditItemForm.swift
@@ -19,6 +19,7 @@ struct EditItemForm: View {
     @State private var price: String
     @State private var nameError: String?
     @State private var amountError: String?
+    @State private var priceError: String?
 
     init(item: Item) {
         self.item = item
@@ -66,9 +67,11 @@ struct EditItemForm: View {
             }
 
             VStack(alignment: .leading) {
-                Text("値段")
-                    .font(.caption)
-                    .foregroundStyle(.gray)
+                Text("値段").font(.caption).foregroundStyle(.gray)
+
+                if let priceError {
+                    Text(priceError).font(.caption).foregroundColor(.red)
+                }
 
                 RepresentableTextField(
                     text: $price,
@@ -88,8 +91,9 @@ struct EditItemForm: View {
     private func validateAndSave() {
         let nameHasError = validateName()
         let amountHasError = validateAmount()
+        let priceHasError = validateAmount()
 
-        if nameHasError || amountHasError {
+        if nameHasError || amountHasError || priceHasError {
             return
         }
 
@@ -122,6 +126,20 @@ struct EditItemForm: View {
             return true
         case .none:
             amountError = nil
+            return false
+        }
+    }
+    
+    private func validatePrice() -> Bool {
+        let priceValidator = ItemPriceValidator(price: price)
+        let priceResult = priceValidator.validate()
+
+        switch priceResult {
+        case .isNotNumber(let priceMessage):
+            priceError = priceMessage
+            return true
+        case .none:
+            priceError = nil
             return false
         }
     }

--- a/shellme/ViewComponents/Forms/EditItemForm.swift
+++ b/shellme/ViewComponents/Forms/EditItemForm.swift
@@ -105,43 +105,24 @@ struct EditItemForm: View {
         let nameValidator = ItemNameValidator(name: name)
         let nameResult = nameValidator.validate()
 
-        switch nameResult {
-        case .required(let nameMessage):
-            nameError = nameMessage
-            return true
-        case .none:
-            nameError = nil
-            return false
-        }
+        nameError = nameResult.errorMessage
+        return nameResult.isNg
     }
 
     private func validateAmount() -> Bool {
         let amountValidator = ItemAmountValidator(amount: amount)
         let amountResult = amountValidator.validate()
 
-        switch amountResult {
-        case .required(let amountMessage), .isNotNumber(let amountMessage),
-            .isLessThanOne(let amountMessage):
-            amountError = amountMessage
-            return true
-        case .none:
-            amountError = nil
-            return false
-        }
+        amountError = amountResult.errorMessage
+        return amountResult.isNg
     }
-    
+
     private func validatePrice() -> Bool {
         let priceValidator = ItemPriceValidator(price: price)
         let priceResult = priceValidator.validate()
-
-        switch priceResult {
-        case .isNotNumber(let priceMessage):
-            priceError = priceMessage
-            return true
-        case .none:
-            priceError = nil
-            return false
-        }
+        
+        priceError = priceResult.errorMessage
+        return priceResult.isNg
     }
 
     private func saveChanges() {

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -59,7 +59,7 @@ struct ScannerView: View {
                         Text("個数").font(.caption).foregroundStyle(.gray)
                         Text("*").foregroundColor(.red)
                     }
-                    
+
                     if let amountError {
                         Text(amountError).font(.caption).foregroundColor(.red)
                     }
@@ -96,7 +96,7 @@ struct ScannerView: View {
             highlightStepMessage()
         }
     }
-    
+
     private func validateAndSave() {
         let nameHasError = validateName()
         let amountHasError = validateAmount()
@@ -139,8 +139,7 @@ struct ScannerView: View {
     }
 
     private func saveItem() {
-        let item = Item(
-            name: name, amount: Int(amount) ?? 1, price: Float(price))
+        let item = Item(name: name, amount: Int(amount)!, price: Float(price))
         modelContext.insert(item)
     }
 

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -37,9 +37,10 @@ struct ScannerView: View {
 
             Form {
                 VStack(alignment: .leading) {
-                    Text("商品名")
-                        .font(.caption)
-                        .foregroundStyle(.gray)
+                    HStack {
+                        Text("商品名").font(.caption).foregroundStyle(.gray)
+                        Text("*").foregroundColor(.red)
+                    }
 
                     if let nameError {
                         Text(nameError)

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -21,6 +21,7 @@ struct ScannerView: View {
     @State private var isHighlighted: Bool = false
     @State private var nameError: String?
     @State private var amountError: String?
+    @State private var priceError: String?
 
     var body: some View {
         VStack {
@@ -71,9 +72,12 @@ struct ScannerView: View {
                 }
 
                 VStack(alignment: .leading) {
-                    Text("値段")
-                        .font(.caption)
-                        .foregroundStyle(.gray)
+                    Text("値段").font(.caption).foregroundStyle(.gray)
+
+                    if let priceError {
+                        Text(priceError).font(.caption).foregroundColor(.red)
+                    }
+
                     RepresentableTextField(
                         text: $price, placeholder: "値段",
                         keyboardType: .decimalPad
@@ -100,8 +104,9 @@ struct ScannerView: View {
     private func validateAndSave() {
         let nameHasError = validateName()
         let amountHasError = validateAmount()
+        let priceHasError = validatePrice()
 
-        if nameHasError || amountHasError {
+        if nameHasError || amountHasError || priceHasError {
             return
         }
 
@@ -134,6 +139,20 @@ struct ScannerView: View {
             return true
         case .none:
             amountError = nil
+            return false
+        }
+    }
+
+    private func validatePrice() -> Bool {
+        let priceValidator = ItemPriceValidator(price: price)
+        let priceResult = priceValidator.validate()
+
+        switch priceResult {
+        case .isNotNumber(let priceMessage):
+            priceError = priceMessage
+            return true
+        case .none:
+            priceError = nil
             return false
         }
     }

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -19,6 +19,7 @@ struct ScannerView: View {
     @State private var price: String = ""
     @State private var currentStep: ScanStep = .nameStep
     @State private var isHighlighted: Bool = false
+    @State private var nameError: String?
 
     var body: some View {
         VStack {
@@ -40,6 +41,12 @@ struct ScannerView: View {
                         .font(.caption)
                         .foregroundStyle(.gray)
 
+                    if let nameError {
+                        Text(nameError)
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+
                     RepresentableTextField(
                         text: $name, placeholder: "商品"
                     )
@@ -54,7 +61,7 @@ struct ScannerView: View {
                         keyboardType: .numberPad
                     )
                 }
-                
+
                 VStack(alignment: .leading) {
                     Text("値段")
                         .font(.caption)
@@ -64,10 +71,9 @@ struct ScannerView: View {
                         keyboardType: .decimalPad
                     )
                 }
+
                 Button("保存") {
-                    saveItem()
-                    resetForm()
-                    dismiss()
+                    validateAndSave()
                 }
                 .frame(maxWidth: .infinity)
             }
@@ -83,16 +89,25 @@ struct ScannerView: View {
         }
     }
 
+    private func validateAndSave() {
+        let validator = ItemNameValidator(name: name)
+        let result = validator.validate()
+
+        switch result {
+        case .required(let message):
+            nameError = message
+            return
+        case .none:
+            nameError = nil
+            saveItem()
+            dismiss()
+        }
+    }
+
     private func saveItem() {
         let item = Item(
             name: name, amount: Int(amount) ?? 1, price: Float(price))
         modelContext.insert(item)
-    }
-
-    private func resetForm() {
-        name = ""
-        amount = ""
-        price = ""
     }
 
     private var stepMessage: String {

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -118,43 +118,24 @@ struct ScannerView: View {
         let nameValidator = ItemNameValidator(name: name)
         let nameResult = nameValidator.validate()
 
-        switch nameResult {
-        case .required(let nameMessage):
-            nameError = nameMessage
-            return true
-        case .none:
-            nameError = nil
-            return false
-        }
+        nameError = nameResult.errorMessage
+        return nameResult.isNg
     }
 
     private func validateAmount() -> Bool {
         let amountValidator = ItemAmountValidator(amount: amount)
         let amountResult = amountValidator.validate()
 
-        switch amountResult {
-        case .required(let amountMessage), .isNotNumber(let amountMessage),
-            .isLessThanOne(let amountMessage):
-            amountError = amountMessage
-            return true
-        case .none:
-            amountError = nil
-            return false
-        }
+        amountError = amountResult.errorMessage
+        return amountResult.isNg
     }
 
     private func validatePrice() -> Bool {
         let priceValidator = ItemPriceValidator(price: price)
         let priceResult = priceValidator.validate()
-
-        switch priceResult {
-        case .isNotNumber(let priceMessage):
-            priceError = priceMessage
-            return true
-        case .none:
-            priceError = nil
-            return false
-        }
+        
+        priceError = priceResult.errorMessage
+        return priceResult.isNg
     }
 
     private func saveItem() {


### PR DESCRIPTION
## 実装内容
エラーとして表示する内容は以下。なお、入力中のバリデーションチェックは、実装が煩雑になるので今回は行わない方針。

- 商品名
  - 商品名が入力されていない
- 個数
  - 整数に変換できない値が入力されている
  - 個数が0以下
  - 個数が入力されていない
- 値段
  - 数字に変換できない値が入力されている

## 補足
- バリデーションの実装は[iOSアプリのバリデーションについて考えてみた](https://blog.mothule.com/ios/swift/ios-swift-validation)を参考に実装した
- 編集画面では[SwiftUI で @State の初期状態を外から受け取る](https://qiita.com/muhiro12/items/1e5580e2aa318a4a69c1)を参考にした
  - 編集画面ではitemをBindableにしていたので、不正な値をテキストフィールドに入力した瞬間、バリデーションを通る前にそれで保存されていた
  - 編集画面では保存ボタンを押す前では保存対象を更新したくないので、State(initialValue)でtextなどのプロパティを一時的に用意した状態で、保存ボタン押下時に引数として受け取ったitemを一気に更新する方針に変更