### PR TITLE
追加ボタン・編集画面に合計金額を表示する

### DIFF
--- a/shellme/ContentView.swift
+++ b/shellme/ContentView.swift
@@ -14,15 +14,6 @@ struct ContentView: View {
     @State private var isAddFormPresented = false
     @State private var isAllDeleteDialogPresented = false
 
-    private var totalPrice: Int {
-        let total: Float = items.reduce(0) { sum, item in
-            if let price = item.price {
-                return sum + (Float(item.amount) * price)
-            }
-            return sum
-        }
-        return Int(total)
-    }
     var body: some View {
         NavigationView {
             ZStack {
@@ -30,10 +21,7 @@ struct ContentView: View {
                     .edgesIgnoringSafeArea(.all)
 
                 VStack {
-                    Text("合計金額: \(totalPrice, format: .currency(code: "JPY"))")
-                        .font(.title2)
-                        .fontWeight(.bold)
-                        .padding(.top, 20)
+                    TotalPrice()
 
                     ZStack {
                         List {

--- a/shellme/ViewComponents/Forms/CreateItemForm.swift
+++ b/shellme/ViewComponents/Forms/CreateItemForm.swift
@@ -21,6 +21,9 @@ struct CreateItemForm: View {
     @FocusState var focus: Bool
 
     var body: some View {
+        TotalPrice()
+            .padding(.top, 20)
+
         Form {
             VStack(alignment: .leading) {
                 HStack {
@@ -71,7 +74,6 @@ struct CreateItemForm: View {
             }
             .frame(maxWidth: .infinity)
         }
-        .presentationDetents([.fraction(0.4)])
     }
 
     private func validateAndSave() {

--- a/shellme/ViewComponents/Forms/EditItemForm.swift
+++ b/shellme/ViewComponents/Forms/EditItemForm.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct EditItemForm: View {
     @Environment(\.modelContext) private var modelContext
-    @Environment(\.dismiss) private var dismiss
 
     var item: Item
     @FocusState var focus: Bool
@@ -29,6 +28,9 @@ struct EditItemForm: View {
     }
 
     var body: some View {
+        TotalPrice()
+            .padding(.top, 20)
+
         Form {
             VStack(alignment: .leading) {
                 HStack {
@@ -98,7 +100,6 @@ struct EditItemForm: View {
         }
 
         saveChanges()
-        dismiss()
     }
 
     private func validateName() -> Bool {

--- a/shellme/ViewComponents/TotalPrice.swift
+++ b/shellme/ViewComponents/TotalPrice.swift
@@ -1,0 +1,34 @@
+//
+//  TotalPrice.swift
+//  shellme
+//
+//  Created by 斉藤祐大 on 2025/02/25.
+//
+
+import SwiftData
+import SwiftUI
+
+struct TotalPrice: View {
+    @Query() private var items: [Item]
+    
+    private var totalPrice: Int {
+        let total: Float = items.reduce(0) { sum, item in
+            if let price = item.price {
+                return sum + (Float(item.amount) * price)
+            }
+            return sum
+        }
+        return Int(total)
+    }
+
+    var body: some View {
+        Text("合計金額: \(totalPrice, format: .currency(code: "JPY"))")
+            .font(.title2)
+            .fontWeight(.bold)
+    }
+}
+
+#Preview {
+    TotalPrice()
+        .modelContainer(SampleData.shared.modelContainer)
+}


### PR DESCRIPTION
- 商品を追加・編集した時に、すぐに変更後の合計金額を知りたいと思った
- そのため、フォームの中に合計金額を表示するようにした
- カメラ撮影の画面は、合計金額を入れるスペースがないので対象外とした