### PR TITLE
保存ボタン・キャンセルボタンのスタイル修正(#32)

### DIFF
--- a/shellme/ViewComponents/Buttons/PrimaryButtonStyle.swift
+++ b/shellme/ViewComponents/Buttons/PrimaryButtonStyle.swift
@@ -1,0 +1,33 @@
+//
+//  SaveButtonStyle.swift
+//  shellme
+//
+//  Created by 斉藤祐大 on 2025/02/25.
+//
+
+import SwiftUI
+
+struct PrimaryButtonStyle: ButtonStyle {
+    var size: ButtonSize
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: size.fontSize))
+            .padding(size.padding)
+            .frame(maxWidth: .infinity)
+            .background(Color.pink)
+            .foregroundColor(.white)
+            .cornerRadius(size.cornerRadius)
+            .overlay(
+                Color.white.opacity(configuration.isPressed ? 0.3 : 0.0)
+                    .cornerRadius(size.cornerRadius)
+            )
+    }
+}
+
+#Preview {
+    Button("保存") {
+        print("保存する")
+    }
+    .buttonStyle(PrimaryButtonStyle(size: .medium))
+}

--- a/shellme/ViewComponents/Buttons/TertiaryButtonStyle.swift
+++ b/shellme/ViewComponents/Buttons/TertiaryButtonStyle.swift
@@ -1,0 +1,36 @@
+//
+//  TertiaryButtonStyle.swift
+//  shellme
+//
+//  Created by 斉藤祐大 on 2025/02/25.
+//
+
+import SwiftUI
+
+struct TertiaryButtonStyle: ButtonStyle {
+    var size: ButtonSize
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: size.fontSize))
+            .padding(size.padding)
+            .frame(maxWidth: .infinity)
+            .background(Color.clear)
+            .foregroundColor(.secondary)
+            .overlay(
+                RoundedRectangle(cornerRadius: size.cornerRadius)
+                    .stroke(Color.secondary, lineWidth: size.borderWidth)
+            )
+            .overlay(
+                Color.white.opacity(configuration.isPressed ? 0.3 : 0.0)
+                    .cornerRadius(size.cornerRadius)
+            )
+    }
+}
+
+#Preview {
+    Button("キャンセル") {
+        print("キャンセルする")
+    }
+    .buttonStyle(TertiaryButtonStyle(size: .medium))
+}

--- a/shellme/ViewComponents/Forms/CreateItemForm.swift
+++ b/shellme/ViewComponents/Forms/CreateItemForm.swift
@@ -69,10 +69,17 @@ struct CreateItemForm: View {
                 )
             }
 
-            Button("保存") {
-                validateAndSave()
+            HStack {
+                Button("キャンセル") {
+                    dismiss()
+                }
+                .buttonStyle(TertiaryButtonStyle(size: .medium))
+
+                Button("保存") {
+                    validateAndSave()
+                }
+                .buttonStyle(PrimaryButtonStyle(size: .medium))
             }
-            .frame(maxWidth: .infinity)
         }
     }
 
@@ -108,7 +115,7 @@ struct CreateItemForm: View {
     private func validatePrice() -> Bool {
         let priceValidator = ItemPriceValidator(price: price)
         let priceResult = priceValidator.validate()
-        
+
         priceError = priceResult.errorMessage
         return priceResult.isNg
     }

--- a/shellme/ViewComponents/Forms/EditItemForm.swift
+++ b/shellme/ViewComponents/Forms/EditItemForm.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct EditItemForm: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
 
     var item: Item
     @FocusState var focus: Bool
@@ -56,7 +57,7 @@ struct EditItemForm: View {
                     Text("個数").font(.caption).foregroundStyle(.gray)
                     Text("*").foregroundColor(.red)
                 }
-                
+
                 if let amountError {
                     Text(amountError).font(.caption).foregroundColor(.red)
                 }
@@ -82,14 +83,21 @@ struct EditItemForm: View {
                 )
             }
 
-            Button("保存") {
-                validateAndSave()
+            HStack {
+                Button("キャンセル") {
+                    dismiss()
+                }
+                .buttonStyle(TertiaryButtonStyle(size: .medium))
+
+                Button("保存") {
+                    validateAndSave()
+                }
+                .buttonStyle(PrimaryButtonStyle(size: .medium))
             }
-            .frame(maxWidth: .infinity)
         }
         .presentationDetents([.fraction(0.45)])
     }
-    
+
     private func validateAndSave() {
         let nameHasError = validateName()
         let amountHasError = validateAmount()
@@ -121,7 +129,7 @@ struct EditItemForm: View {
     private func validatePrice() -> Bool {
         let priceValidator = ItemPriceValidator(price: price)
         let priceResult = priceValidator.validate()
-        
+
         priceError = priceResult.errorMessage
         return priceResult.isNg
     }

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -84,10 +84,17 @@ struct ScannerView: View {
                     )
                 }
 
-                Button("保存") {
-                    validateAndSave()
+                HStack {
+                    Button("キャンセル") {
+                        dismiss()
+                    }
+                    .buttonStyle(TertiaryButtonStyle(size: .medium))
+
+                    Button("保存") {
+                        validateAndSave()
+                    }
+                    .buttonStyle(PrimaryButtonStyle(size: .medium))
                 }
-                .frame(maxWidth: .infinity)
             }
         }
         .task {


### PR DESCRIPTION
## 修正内容
保存ボタンにプライマリの色を当て、キャンセルボタンも用意した

| 改修前 | 本PR |
| --- | --- |
| <img width="414" alt="Image" src="https://github.com/user-attachments/assets/5c657efa-aed0-4730-9c79-c9e10a4380a6" /> |  <img width="395" alt="Image" src="https://github.com/user-attachments/assets/9cd76798-107c-4026-bd7a-8ba4c18c9636" /> |