### PR TITLE
商品リストにチェックボックスを追加(#35)

### DIFF
--- a/shellme/ContentView.swift
+++ b/shellme/ContentView.swift
@@ -30,12 +30,44 @@ struct ContentView: View {
                                     destination: EditItemForm(item: item)
                                 ) {
                                     HStack {
+
+                                        Button(action: {
+                                            toggleCheck(item: item)
+                                        }) {
+                                            Image(
+                                                systemName: item.isChecked
+                                                    ? "checkmark.circle.fill"
+                                                    : "circle"
+                                            )
+                                            .resizable()
+                                            .scaledToFit()
+                                            .frame(width: 20, height: 20)
+                                            .foregroundColor(
+                                                item.isChecked ? .gray : .pink)
+                                        }
+                                        .contentShape(Rectangle())
+                                        .buttonStyle(.plain)
+
                                         Text(item.name)
+                                            .foregroundColor(
+                                                item.isChecked
+                                                    ? .gray : .primary
+                                            )
+                                            .strikethrough(
+                                                item.isChecked, color: .gray
+                                            )
                                             .frame(
                                                 maxWidth: .infinity,
                                                 alignment: .leading)
 
                                         Text(String(item.amount))
+                                            .foregroundColor(
+                                                item.isChecked
+                                                    ? .gray : .primary
+                                            )
+                                            .strikethrough(
+                                                item.isChecked, color: .gray
+                                            )
                                             .frame(
                                                 width: 30, alignment: .trailing)
 
@@ -43,11 +75,25 @@ struct ContentView: View {
                                             Text(
                                                 "\(price, format: .currency(code: "JPY"))"
                                             )
+                                            .foregroundColor(
+                                                item.isChecked
+                                                    ? .gray : .primary
+                                            )
+                                            .strikethrough(
+                                                item.isChecked, color: .gray
+                                            )
                                             .frame(
                                                 width: 100, alignment: .trailing
                                             )
                                         } else {
                                             Text("-")
+                                                .foregroundColor(
+                                                    item.isChecked
+                                                        ? .gray : .primary
+                                                )
+                                                .strikethrough(
+                                                    item.isChecked, color: .gray
+                                                )
                                                 .frame(
                                                     width: 100,
                                                     alignment: .trailing)
@@ -94,7 +140,8 @@ struct ContentView: View {
                     }
                 }
             }
-            .alert("すべてのアイテムを削除しますか？", isPresented: $isAllDeleteDialogPresented) {
+            .alert("すべてのアイテムを削除しますか？", isPresented: $isAllDeleteDialogPresented)
+            {
                 Button("キャンセル", role: .cancel) {}
                 Button("削除", role: .destructive) {
                     deleteAllItems()
@@ -118,6 +165,10 @@ struct ContentView: View {
         for item in items {
             modelContext.delete(item)
         }
+    }
+
+    private func toggleCheck(item: Item) {
+        item.isChecked.toggle()
     }
 }
 

--- a/shellme/Model/Item.swift
+++ b/shellme/Model/Item.swift
@@ -14,12 +14,14 @@ final class Item {
     var amount: Int
     var price: Float?
     var createdAt: Date
+    var isChecked: Bool
 
-    init(name: String, amount: Int, price: Float? = nil) {
+    init(name: String, amount: Int, price: Float? = nil, isChecked: Bool = false) {
         self.name = name
         self.amount = amount
         self.price = price
         self.createdAt = Date()
+        self.isChecked = isChecked
     }
 
     @MainActor


### PR DESCRIPTION
## 変更点
- リストの左側にチェックボックスを用意し、購入したもののとそうでないものを判断できるようにする

<img src="https://github.com/user-attachments/assets/1f921dbf-c5b3-4831-b07e-278821e24e75" width="500px">
