### PR TITLE
DataScannerViewで連続入力を出来るようにし、それに伴いScannerViewのレイアウトも修正する

### DIFF
--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -113,7 +113,9 @@ struct ScannerView: View {
     }
 
     private func validateAndSave() {
-        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder), to: nil, from: nil,
+            for: nil)
 
         let nameHasError = validateName()
         let amountHasError = validateAmount()

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -57,6 +57,19 @@ struct ScannerView: View {
                 }
 
                 VStack(alignment: .leading) {
+                    Text("値段").font(.caption).foregroundStyle(.gray)
+
+                    if let priceError {
+                        Text(priceError).font(.caption).foregroundColor(.red)
+                    }
+
+                    RepresentableTextField(
+                        text: $price, placeholder: "値段",
+                        keyboardType: .decimalPad
+                    )
+                }
+                
+                VStack(alignment: .leading) {
                     HStack {
                         Text("個数").font(.caption).foregroundStyle(.gray)
                         Text("*").foregroundColor(.red)
@@ -69,19 +82,6 @@ struct ScannerView: View {
                     RepresentableTextField(
                         text: $amount, placeholder: "個数",
                         keyboardType: .numberPad
-                    )
-                }
-
-                VStack(alignment: .leading) {
-                    Text("値段").font(.caption).foregroundStyle(.gray)
-
-                    if let priceError {
-                        Text(priceError).font(.caption).foregroundColor(.red)
-                    }
-
-                    RepresentableTextField(
-                        text: $price, placeholder: "値段",
-                        keyboardType: .decimalPad
                     )
                 }
 

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -107,6 +107,8 @@ struct ScannerView: View {
     }
 
     private func validateAndSave() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+
         let nameHasError = validateName()
         let amountHasError = validateAmount()
         let priceHasError = validatePrice()

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -118,7 +118,9 @@ struct ScannerView: View {
         }
 
         saveItem()
-        dismiss()
+        resetForm()
+        isScanning = true
+        currentStep = .nameStep
     }
 
     private func validateName() -> Bool {
@@ -140,7 +142,7 @@ struct ScannerView: View {
     private func validatePrice() -> Bool {
         let priceValidator = ItemPriceValidator(price: price)
         let priceResult = priceValidator.validate()
-        
+
         priceError = priceResult.errorMessage
         return priceResult.isNg
     }
@@ -166,6 +168,12 @@ struct ScannerView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             isHighlighted = false
         }
+    }
+
+    private func resetForm() {
+        name = ""
+        amount = ""
+        price = ""
     }
 }
 

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -25,10 +25,6 @@ struct ScannerView: View {
 
     var body: some View {
         VStack {
-            Text(stepMessage)
-                .foregroundColor(isHighlighted ? .yellow : .primary)
-                .animation(.easeInOut(duration: 0.5), value: isHighlighted)
-
             DataScanner(
                 isScanning: $isScanning,
                 isShowAlert: $isShowAlert,
@@ -36,6 +32,11 @@ struct ScannerView: View {
                 price: $price,
                 currentStep: $currentStep
             )
+            
+            Text(stepMessage)
+                .foregroundColor(isHighlighted ? .yellow : .primary)
+                .animation(.easeInOut(duration: 0.5), value: isHighlighted)
+
 
             Form {
                 VStack(alignment: .leading) {
@@ -155,9 +156,9 @@ struct ScannerView: View {
     private var stepMessage: String {
         switch currentStep {
         case .nameStep:
-            return "商品名をタップしてください"
+            return "文字にハイライトが出たら、商品名をタップしてください"
         case .priceStep:
-            return "税込の値段をタップしてください"
+            return "文字にハイライトが出たら、税込の値段をタップしてください"
         case .completed:
             return "入力内容を確認し、保存してください"
         }

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -32,11 +32,11 @@ struct ScannerView: View {
                 price: $price,
                 currentStep: $currentStep
             )
-            
+
             Text(stepMessage)
+                .multilineTextAlignment(.center)
                 .foregroundColor(isHighlighted ? .yellow : .primary)
                 .animation(.easeInOut(duration: 0.5), value: isHighlighted)
-
 
             Form {
                 VStack(alignment: .leading) {
@@ -68,7 +68,7 @@ struct ScannerView: View {
                         keyboardType: .decimalPad
                     )
                 }
-                
+
                 VStack(alignment: .leading) {
                     HStack {
                         Text("個数").font(.caption).foregroundStyle(.gray)
@@ -160,7 +160,7 @@ struct ScannerView: View {
         case .priceStep:
             return "文字にハイライトが出たら、税込の値段をタップしてください"
         case .completed:
-            return "入力内容を確認し、保存してください"
+            return "個数の入力をし、入力内容の確認をした後、保存してください"
         }
     }
 

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -165,7 +165,7 @@ struct ScannerView: View {
         case .priceStep:
             return "文字にハイライトが出たら、税込の値段をタップしてください"
         case .completed:
-            return "個数の入力をし、入力内容の確認をした後、保存してください"
+            return "個数を入力し、入力内容の確認をした後、保存してください"
         }
     }
 

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -25,13 +25,18 @@ struct ScannerView: View {
 
     var body: some View {
         VStack {
-            DataScanner(
-                isScanning: $isScanning,
-                isShowAlert: $isShowAlert,
-                name: $name,
-                price: $price,
-                currentStep: $currentStep
-            )
+            if isScanning {
+                DataScanner(
+                    isScanning: $isScanning,
+                    isShowAlert: $isShowAlert,
+                    name: $name,
+                    price: $price,
+                    currentStep: $currentStep
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
+            } else {
+                EmptyView()
+            }
 
             Text(stepMessage)
                 .multilineTextAlignment(.center)
@@ -104,6 +109,7 @@ struct ScannerView: View {
         .onChange(of: currentStep) {
             highlightStepMessage()
         }
+        .animation(.easeInOut(duration: 0.5), value: isScanning)
     }
 
     private func validateAndSave() {

--- a/shellme/ViewComponents/Scanners/ScannerView.swift
+++ b/shellme/ViewComponents/Scanners/ScannerView.swift
@@ -12,7 +12,7 @@ struct ScannerView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
 
-    @State private var isScanning: Bool = false
+    @State private var isScanning: Bool = true
     @State private var isShowAlert: Bool = false
     @State private var name: String = ""
     @State private var amount: String = ""
@@ -97,9 +97,6 @@ struct ScannerView: View {
                     .buttonStyle(PrimaryButtonStyle(size: .medium))
                 }
             }
-        }
-        .task {
-            isScanning.toggle()
         }
         .onAppear {
             highlightStepMessage()


### PR DESCRIPTION
## 本PRの挙動

https://github.com/user-attachments/assets/62cef2a7-a2b8-438f-b28c-0c725b0daee7

## 変更の目的
カメラによる入力を連続で行えるようにする。
理由として、同じ商品コーナーにある商品を追加したいとなった時に、追加する度に画面を開き直さないといけないのは面倒であったため。

## 変更内容
- スキャナー表示・非表示の切り替えはアコーディオンみたいなアニメーションを入れて制御する
  - スキャナーを常時表示していると、個数を入力するときやテキストを修正するときにキーボードが出てくるので、スキャナーが邪魔になる
  - 唐突な表示・非表示の切り替えは使っていてびっくりしたのでアニメーションで徐々に切り替わるようにする
- ガイドのテキストを中央寄せになるようにする
  - 今まではテキストが切り替わると、テキストの位置が変わってしまい違和感を覚えたので中央揃えで統一させる
- ガイドの表示位置を入力欄のすぐ上にする
  - スキャナーの上だとガイドがあることに気づきづらいと思ったため修正