### PR TITLE
設定画面ボタンからプライバシーポリシー・ライセンス画面に飛べるようにする(#29)

### DIFF
--- a/shellme.xcodeproj/project.pbxproj
+++ b/shellme.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		914081642D746F1F00706F79 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 914081632D746F1F00706F79 /* GoogleMobileAds */; };
+		91D889212D88538D00FC1178 /* LicenseList in Frameworks */ = {isa = PBXBuildFile; productRef = 91D889202D88538D00FC1178 /* LicenseList */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				91D889212D88538D00FC1178 /* LicenseList in Frameworks */,
 				914081642D746F1F00706F79 /* GoogleMobileAds in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -131,6 +133,7 @@
 			name = shellme;
 			packageProductDependencies = (
 				914081632D746F1F00706F79 /* GoogleMobileAds */,
+				91D889202D88538D00FC1178 /* LicenseList */,
 			);
 			productName = shellme;
 			productReference = 91E9E9322D3CCA2600735BC9 /* shellme.app */;
@@ -217,6 +220,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				914081622D746F1F00706F79 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
+				91D8891F2D8852C000FC1178 /* XCRemoteSwiftPackageReference "LicenseList" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 91E9E9332D3CCA2600735BC9 /* Products */;
@@ -604,6 +608,14 @@
 				minimumVersion = 12.1.0;
 			};
 		};
+		91D8891F2D8852C000FC1178 /* XCRemoteSwiftPackageReference "LicenseList" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/cybozu/LicenseList";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -611,6 +623,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 914081622D746F1F00706F79 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
 			productName = GoogleMobileAds;
+		};
+		91D889202D88538D00FC1178 /* LicenseList */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 91D8891F2D8852C000FC1178 /* XCRemoteSwiftPackageReference "LicenseList" */;
+			productName = LicenseList;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/shellme.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/shellme.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "3b9752ff554d5fdc91a7c01c2322a5d851b0979c36f02eb55188d9ab9e3d7e77",
+  "originHash" : "7169b4c934253d0541333c14437349a5a5dd57d6a8cd463a2e8483bd37bb57cb",
   "pins" : [
+    {
+      "identity" : "licenselist",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/cybozu/LicenseList",
+      "state" : {
+        "revision" : "4801461b9ca8eee843c19ab8fe88a590ce064e15",
+        "version" : "2.0.1"
+      }
+    },
     {
       "identity" : "swift-package-manager-google-mobile-ads",
       "kind" : "remoteSourceControl",

--- a/shellme/ContentView.swift
+++ b/shellme/ContentView.swift
@@ -16,6 +16,29 @@ struct ContentView: View {
     @State private var isAddFormPresented = false
     @State private var isAllDeleteDialogPresented = false
 
+    init() {
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = UIColor.systemPink
+        
+        appearance.titleTextAttributes = [
+            .foregroundColor: UIColor.white
+        ]
+
+        let backButtonAppearance = UIBarButtonItemAppearance()
+        backButtonAppearance.normal.titleTextAttributes = [
+            .foregroundColor: UIColor.white
+        ]
+        appearance.backButtonAppearance = backButtonAppearance
+
+        let backImage = UIImage(systemName: "chevron.backward")?.withTintColor(
+            .white, renderingMode: .alwaysOriginal)
+        appearance.setBackIndicatorImage(
+            backImage, transitionMaskImage: backImage)
+
+        UINavigationBar.appearance().standardAppearance = appearance
+        UINavigationBar.appearance().scrollEdgeAppearance = appearance
+    }
+
     var body: some View {
         NavigationView {
             ZStack {
@@ -24,6 +47,7 @@ struct ContentView: View {
 
                 VStack {
                     TotalPrice()
+                        .padding(.top, 20)
 
                     ZStack {
                         List {
@@ -134,13 +158,26 @@ struct ContentView: View {
                         .frame(width: 320, height: 50)
                 }
             }
+            .toolbarBackground(Color.pink, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .navigationBarLeading) {
                     Button(role: .destructive) {
                         isAllDeleteDialogPresented = true
                     } label: {
                         Image(systemName: "trash")
-                            .foregroundColor(.red)
+                            .resizable()
+                            .frame(width: 30, height: 30)
+                            .foregroundColor(.white)
+                    }
+                }
+
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    NavigationLink(destination: SettingView()) {
+                        Image(systemName: "gearshape.fill")
+                            .resizable()
+                            .frame(width: 30, height: 30)
+                            .foregroundColor(.white)
                     }
                 }
             }

--- a/shellme/ViewComponents/Settings/OSS/OssLicencesList.swift
+++ b/shellme/ViewComponents/Settings/OSS/OssLicencesList.swift
@@ -1,0 +1,22 @@
+//
+//  OssLicencesList.swift
+//  shellme
+//
+//  Created by 斉藤祐大 on 2025/03/17.
+//
+
+import LicenseList
+import SwiftUI
+
+struct OssLicencesList: View {
+    var body: some View {
+        LicenseListView()
+            .licenseViewStyle(.withRepositoryAnchorLink)
+            .navigationTitle("OSSライセンス")
+            .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    OssLicencesList()
+}

--- a/shellme/ViewComponents/Settings/SettingView.swift
+++ b/shellme/ViewComponents/Settings/SettingView.swift
@@ -1,0 +1,31 @@
+//
+//  SettingView.swift
+//  shellme
+//
+//  Created by 斉藤祐大 on 2025/03/16.
+//
+
+import SwiftUI
+
+struct SettingView: View {
+    let privacyPolicyURL = URL(
+        string: "https://okunichiyou.github.io/shellme-docs/privacy-policy")!
+    let ossLicenseURL = URL(string: "https://yourosslicenseurl.com")!
+
+    var body: some View {
+        List {
+            Link("プライバシーポリシー", destination: privacyPolicyURL)
+
+            NavigationLink {
+                OssLicencesList()
+            } label: {
+                Text("OSSライセンス")
+            }
+        }
+
+    }
+}
+
+#Preview {
+    SettingView()
+}


### PR DESCRIPTION
## やったこと

### プラポリ対応
- 対応が必須なのでプラポリへのリンクを作成
- プラポリ自体は別リポジトリでGithub Pagesで公開している
- 内容としては、Admobを使っているのでデータの使用の項目に該当するため、プラポリにその旨を記載した

> プライバシーに関するリンク
> プロダクトページに以下のリンクを追加することで、ユーザーがアプリのプライバシーポリシーに容易にアクセスし、アプリ内の自分のデータを管理できるようになります。
>
>プライバシーポリシー（必須）：一般公開するプライバシーポリシーのURL。
> https://developer.apple.com/jp/app-store/app-privacy-details/


### OSSライセンス対応
- AdmobのパッケージはApache License 2.0なので頒布するときにアプリ内からライセンス条項にアクセスできるようにする必要がある
- ライセンス条項のリスト表示はLicence Listという別のライブラリを使って実装
  - 今後ライブラリを追加しても自動でリストが追加される