### PR TITLE
ATTに同意したときにクラッシュする問題の解消(#49)

### DIFF
--- a/shellme/ContentView.swift
+++ b/shellme/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
     init() {
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = UIColor.systemPink
-        
+
         appearance.titleTextAttributes = [
             .foregroundColor: UIColor.white
         ]
@@ -198,9 +198,12 @@ struct ContentView: View {
             NotificationCenter.default.publisher(
                 for: UIApplication.didBecomeActiveNotification)
         ) { _ in
-            ATTrackingManager.requestTrackingAuthorization(completionHandler: {
-                _ in
-            })
+            OperationQueue.main.addOperation {
+                ATTrackingManager.requestTrackingAuthorization(
+                    completionHandler: {
+                        _ in
+                    })
+            }
         }
     }
 


### PR DESCRIPTION
- 解消できた根本的な理由はわかっていない
    - 調べてもそれらしい回答は見られなかった
- エラーログを見る限り、queueで発生していそうだったので取り敢えず強制的にmainのキューで実行するようにしたら治った
- もしかしたらSwift 6にしていて、非同期周りの仕様が変わっているのかもしれない