### PR TITLE
NavigationViewをStackに変更して、iPadでの表示が崩れないように修正(#55)

### DIFF
--- a/shellme/ContentView.swift
+++ b/shellme/ContentView.swift
@@ -40,7 +40,7 @@ struct ContentView: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ZStack {
                 Color(.systemGroupedBackground)
                     .edgesIgnoringSafeArea(.all)


### PR DESCRIPTION
以下のようになるように修正。iPhoneの表示の挙動は変わらないことも確認

![Simulator Screenshot - iPad Air 13-inch (M2) - 2025-03-22 at 22 04 56](https://github.com/user-attachments/assets/b875e29a-3bf3-417c-9eca-a95438d223b0)
